### PR TITLE
ST-2560: Add support for building debian and rhel images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,9 @@ dockerfile {
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     slackChannel = 'connect-notification'
     upstreamProjects = []
-    dockerPullDeps = ['confluentinc/cp-base']
+    dockerPullDeps = ['confluentinc/cp-base-new']
     usePackages = true
     cron = '' // Disable the cron because this job requires parameters
+    cpImages = true
+    osTypes = ['deb8', 'rhel8']
 }

--- a/kafka-mqtt/Dockerfile.deb8
+++ b/kafka-mqtt/Dockerfile.deb8
@@ -16,13 +16,13 @@
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=latest
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/kafka-mqtt/Dockerfile.rhel8
+++ b/kafka-mqtt/Dockerfile.rhel8
@@ -1,0 +1,69 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+
+ENV COMPONENT=kafka-mqtt
+
+# standart non-encrypted MQTT port
+EXPOSE 1883
+
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && yum install -y confluent-${COMPONENT}-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/*  \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && chmod -R ag+w /etc/confluent-${COMPONENT}
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/kafka-mqtt/include/etc/confluent/docker/admin.properties.template
+++ b/kafka-mqtt/include/etc/confluent/docker/admin.properties.template
@@ -1,4 +1,4 @@
 {% set security_props = env_to_props('KAFKA_MQTT_PRODUCER_', '') -%}
-{% for name, value in security_props.iteritems() -%}
+{% for name, value in security_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/kafka-mqtt/include/etc/confluent/docker/kafka-mqtt.properties.template
+++ b/kafka-mqtt/include/etc/confluent/docker/kafka-mqtt.properties.template
@@ -1,4 +1,4 @@
 {% set kr_props = env_to_props('KAFKA_MQTT_', '') -%}
-{% for name, value in kr_props.iteritems() -%}
+{% for name, value in kr_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/kafka-mqtt/include/etc/confluent/docker/log4j.properties.template
+++ b/kafka-mqtt/include/etc/confluent/docker/log4j.properties.template
@@ -7,7 +7,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] [%t] %p %m (%c:%L)%n
 
 {% if env['KAFKA_MQTT_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['KAFKA_MQTT_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Renamed the Dockerfile to Dockerfile.deb8, and added Dockerfile.rhel8. The image now uses cp-base-new because we are building multiple versions of the new base image, one of which is the existing deb8 version which will still get used here. So to clarify, this will not upgrade the debian image to use a new version of debian even though we are using cp-base-new.

I have tested the debian image locally and it worked with cp-demo. Testing of the rhel image with cp-demo is still on going.