### PR TITLE
ST-2560: Adding labels required by RedHat container registry

### DIFF
--- a/kafka-mqtt/Dockerfile.deb8
+++ b/kafka-mqtt/Dockerfile.deb8
@@ -21,13 +21,13 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
-# Make sure you use an appropriate contact address.
 LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-mqtt-images"
 
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO

--- a/kafka-mqtt/Dockerfile.rhel8
+++ b/kafka-mqtt/Dockerfile.rhel8
@@ -20,14 +20,19 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
+ARG GIT_COMMIT
 
-# Make sure you use an appropriate contact address.
 LABEL maintainer="partner-support@confluent.io"
+LABEL vendor="Confluent"
+LABEL version=$GIT_COMMIT
+LABEL release=$PROJECT_VERSION
+LABEL name=$ARTIFACT_ID
+LABEL summary="Confluent MQTT Proxy delivers a Kafka-native MQTT proxy to allow organizations to eliminate the additional cost and lag of intermediate MQTT brokers."
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-mqtt-images"
 
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO


### PR DESCRIPTION
These labels are required to pass the RedHat certification process for uploading images to the container registry.