### PR TITLE
fix: Restore root group write access to directories

### DIFF
--- a/kafka-mqtt/Dockerfile.ubi8
+++ b/kafka-mqtt/Dockerfile.ubi8
@@ -66,8 +66,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && chown appuser:appuser -R /etc/confluent-${COMPONENT} \
-    && chmod -R g+w /etc/confluent-${COMPONENT}
+    && chown appuser:root -R /etc/confluent-${COMPONENT} \
+    && chmod -R ug+w /etc/confluent-${COMPONENT}
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 


### PR DESCRIPTION
This restores the root groups write access to confluent service directories.

Internally (@rohit2b) and externally (@erikgb) this change works in an OpenShift context.