### PR TITLE
Enable servicebot for `kafka-mqtt-images`

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,9 @@
+name: kafka-mqtt-images
+lang: unknown
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore: 
+  enable: true
+  pipeline_type: cp-dockerfile


### PR DESCRIPTION
> cc-service-bot is an automation tooling that can help with maintaining project configurations (esp CI build pipeline). We will be using this tool to help with the migration and future management of CI build logic for your project(s)
* Add service.yml